### PR TITLE
Accept non spaces on operations

### DIFF
--- a/lib/soap-server.js
+++ b/lib/soap-server.js
@@ -29,7 +29,7 @@ function SoapOperation(name, service, operation){
 	this.inputs = {};
 	this.output = {type: 'string'};
 
-	var regex = /^function\s+\(([^)]+)\)/;
+	var regex = /^function\s?\(([^)]+)\)/;
 	var operationString = operation + '';
 	var matches = regex.exec(operationString);
 	var args = matches[1].split(',');


### PR DESCRIPTION
Changes in regular expression where it forces \s+ to \s?. When the developer does not put spaces it throws an error.